### PR TITLE
Refactor dayjs

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -4,11 +4,6 @@ import "./index.css";
 import { App } from "./App";
 import reportWebVitals from "./reportWebVitals";
 
-import dayjs from "dayjs";
-import "dayjs/locale/ja";
-
-dayjs.locale("ja");
-
 ReactDOM.render(
   <React.StrictMode>
     <App />

--- a/src/libs/date/date.ts
+++ b/src/libs/date/date.ts
@@ -3,6 +3,10 @@ import "dayjs/locale/ja";
 
 dayjs.locale("ja");
 
-export const parseFormat = (data: Date, format = "YYYY/MM/DD HH:mm:ss") => {
+const format = (data: Date, format = "YYYY/MM/DD HH:mm:ss") => {
   return dayjs(data).format(format);
+};
+
+export const date = {
+  format,
 };

--- a/src/libs/date/date.ts
+++ b/src/libs/date/date.ts
@@ -1,0 +1,8 @@
+import dayjs from "dayjs";
+import "dayjs/locale/ja";
+
+dayjs.locale("ja");
+
+export const parseFormat = (data: Date, format = "YYYY/MM/DD HH:mm:ss") => {
+  return dayjs(data).format(format);
+};

--- a/src/libs/date/index.ts
+++ b/src/libs/date/index.ts
@@ -1,2 +1,1 @@
 export * from "./date";
-export * from "./http";

--- a/src/pages/todos/todo-detail/components/todo-detail.component.tsx
+++ b/src/pages/todos/todo-detail/components/todo-detail.component.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { todos } from "../../todo-mock";
-import dayjs from "dayjs";
+import { parseFormat } from "../../../../libs";
 
 type TodoDetailProps = {
   id: number;
@@ -22,11 +22,11 @@ export const TodoDetail: React.FC<TodoDetailProps> = (props) => {
           </tr>
           <tr>
             <td>作成日</td>
-            <td>{dayjs(todo.createdAt).format("YYYY/MM/DD HH:mm:ss")}</td>
+            <td>{parseFormat(todo.createdAt, "YYYY/MM/DD HH:mm:ss")}</td>
           </tr>
           <tr>
             <td>更新日</td>
-            <td>{dayjs(todo.createdAt).format("YYYY/MM/DD HH:mm:ss")}</td>
+            <td>{parseFormat(todo.updatedAt, "YYYY/MM/DD HH:mm:ss")}</td>
           </tr>
         </tbody>
       </table>

--- a/src/pages/todos/todo-detail/components/todo-detail.component.tsx
+++ b/src/pages/todos/todo-detail/components/todo-detail.component.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { todos } from "../../todo-mock";
-import { parseFormat } from "../../../../libs";
+import { date } from "../../../../libs";
 
 type TodoDetailProps = {
   id: number;
@@ -22,11 +22,11 @@ export const TodoDetail: React.FC<TodoDetailProps> = (props) => {
           </tr>
           <tr>
             <td>作成日</td>
-            <td>{parseFormat(todo.createdAt, "YYYY/MM/DD HH:mm:ss")}</td>
+            <td>{date.format(todo.createdAt, "YYYY/MM/DD HH:mm:ss")}</td>
           </tr>
           <tr>
             <td>更新日</td>
-            <td>{parseFormat(todo.updatedAt, "YYYY/MM/DD HH:mm:ss")}</td>
+            <td>{date.format(todo.updatedAt, "YYYY/MM/DD HH:mm:ss")}</td>
           </tr>
         </tbody>
       </table>


### PR DESCRIPTION
dayjsを直接entry fileに記述するのは避けたいので、ラッパーを作り対応した。

dayjsに関する処理は `libs/date` にまとめて、componentからはこのライブラリを通してdayjsを利用する。

何が嬉しい？
→テストするときにmockがやりやすい